### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -15,7 +15,7 @@
     "tags": [
 		"messagepack", "message", "serialization", "data"
     ],
-    "license": "perl",
+    "license": "Artistic-2.0",
     "test-depends": [ ],
     "provides": {
 		"MessagePack::Class" : "lib/MessagePack/Class.pm"


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license